### PR TITLE
Add FHIR Patient/$everything

### DIFF
--- a/app/controllers/api/v1/curated_models_controller.rb
+++ b/app/controllers/api/v1/curated_models_controller.rb
@@ -29,12 +29,6 @@ module Api
 
       private
 
-      def wrap_in_bundle(results)
-        # get just the FHIR resources, but then wrap it in an Entry.
-        resources = results.map { |r| { resource: JSON.parse(r.resource) } }
-        FHIR::Bundle.new(type: 'searchset', entry: resources)
-      end
-
       def authorized_resources
         @model_class.where(profile: @profile)
       end

--- a/app/controllers/api/v1/patients_controller.rb
+++ b/app/controllers/api/v1/patients_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class PatientsController < ApiController
       def index
-        patients = current_resource_owner.profiles.map { |p| map_profile_to_patient(p) }
+        patients = current_resource_owner.profiles.map { |p| { resource: map_profile_to_patient(p).to_hash } }
 
         bundle = FHIR::Bundle.new(type: 'searchset', entry: patients)
 
@@ -17,6 +17,20 @@ module Api
 
         # pre-converting to json is a workaround for a bug w/ rails & fhir_models
         render json: patient.to_json, status: :ok
+      end
+
+      def everything
+        profile = find_profile
+        patient = map_profile_to_patient(profile)
+
+        everything_else = profile.all_resources
+
+        bundle = wrap_in_bundle(everything_else)
+
+        bundle.entry.unshift(FHIR::Bundle::Entry.new(resource: patient.to_hash))
+
+        # pre-converting to json is a workaround for a bug w/ rails & fhir_models
+        render json: bundle.to_json, status: :ok
       end
 
       private

--- a/app/controllers/api/v1/patients_controller.rb
+++ b/app/controllers/api/v1/patients_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class PatientsController < ApiController
       def index
-        patients = current_resource_owner.profiles.map { |p| { resource: map_profile_to_patient(p).to_hash } }
+        patients = current_resource_owner.profiles.map { |p| wrap_in_entry(map_profile_to_patient(p)) }
 
         bundle = FHIR::Bundle.new(type: 'searchset', entry: patients)
 
@@ -22,12 +22,10 @@ module Api
       def everything
         profile = find_profile
         patient = map_profile_to_patient(profile)
-
         everything_else = profile.all_resources
-
         bundle = wrap_in_bundle(everything_else)
 
-        bundle.entry.unshift(FHIR::Bundle::Entry.new(resource: patient.to_hash))
+        bundle.entry.insert(0, wrap_in_entry(patient))
 
         # pre-converting to json is a workaround for a bug w/ rails & fhir_models
         render json: bundle.to_json, status: :ok

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -2,4 +2,10 @@
 
 class ApiController < ApplicationController
   # before_action -> { doorkeeper_authorize! :api }
+
+  def wrap_in_bundle(results)
+    # get just the FHIR resources, but then wrap it in an Entry.
+    resources = results.map { |r| { resource: JSON.parse(r.resource) } }
+    FHIR::Bundle.new(type: 'searchset', entry: resources)
+  end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,7 +5,19 @@ class ApiController < ApplicationController
 
   def wrap_in_bundle(results)
     # get just the FHIR resources, but then wrap it in an Entry.
-    resources = results.map { |r| { resource: JSON.parse(r.resource) } }
+    resources = results.map { |r| wrap_in_entry(r.resource) }
     FHIR::Bundle.new(type: 'searchset', entry: resources)
+  end
+
+  def wrap_in_entry(obj)
+    # FHIR::X.new() requires that these be hashes, not strings or full FHIR objects
+
+    if obj.is_a? String
+      obj = JSON.parse(obj)
+    elsif obj.is_a? FHIR::Model
+      obj = obj.to_hash
+    end
+
+    { resource: obj }
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -19,6 +19,9 @@ class Profile < ApplicationRecord
   has_many :medication_statements
   has_many :observations
   has_many :procedures
+  # IMPORTANT - if adding new resource types above,
+  #             also add them to the all_resources method below
+
   # resources are the raw resources that are created from transactions, they
   # do not equate to the currated data models resources
   has_many :resources
@@ -26,6 +29,23 @@ class Profile < ApplicationRecord
   def has_provider?(provider_id)
     return false if provider_id.nil?
     !providers.find_by(id: provider_id).nil?
+  end
+
+  def all_resources
+    # there are hackish ways to do this, but not worth it at this point
+    types = %i[allergy_intolerances care_plans conditions devices
+               documents encounters goals immunizations
+               medication_administrations medication_requests
+               medication_statements observations procedures]
+
+    rs = []
+
+    types.each do |t|
+      rs_by_type = send(t)
+      rs.push(*rs_by_type)
+    end
+
+    rs
   end
 
   def reference

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,9 @@ Rails.application.routes.draw do
       end
       resources :providers, only: %i[index show]
 
-      resources :Patient, controller: :patients, only: %i[index show]
+      resources :Patient, controller: :patients, only: %i[index show] do
+        get '$everything', on: :member, to: 'patients#everything'
+      end
       # curated models as FHIR
       curated_models.each do |cm|
         resources cm.to_s.classify.to_sym, controller: cm, only: %i[index show]

--- a/test/controllers/api/v1/patients_controller_test.rb
+++ b/test/controllers/api/v1/patients_controller_test.rb
@@ -21,6 +21,33 @@ module Api
         assert_equal(profile.last_name, patient.name[0].family)
       end
 
+      test 'user should be able to get $everything on their own patient record' do
+        user = users(:harry)
+        token = generate_token(user.id)
+        profile = profiles(:jills_profile)
+        get "/api/v1/Patient/#{profile.id}/$everything", params: { access_token: token.token }
+        assert_response :success
+
+        bundle = FHIR::Json.from_json(@response.body)
+        assert_not_nil(bundle)
+        assert_equal('Bundle', bundle.resourceType)
+        assert_equal(3, bundle.entry.size)
+
+        patient = bundle.entry[0].resource
+        assert_equal('Patient', patient.resourceType)
+
+        assert_equal(profile.first_name, patient.name[0].given[0])
+        assert_equal(profile.last_name, patient.name[0].family)
+
+        condition = bundle.entry[1].resource
+        assert_equal('Condition', condition.resourceType)
+        assert_equal('Q84.1', condition.code.coding[0].code)
+
+        condition = bundle.entry[2].resource
+        assert_equal('Condition', condition.resourceType)
+        assert_equal('W61.62', condition.code.coding[0].code)
+      end
+
       test 'user should be able to see all patient records they have access to' do
         user = users(:harry)
         token = generate_token(user.id)
@@ -33,7 +60,7 @@ module Api
         assert_equal('Bundle', bundle.resourceType)
         assert_equal(2, bundle.entry.size)
 
-        entries = bundle.entry.sort_by(&:id)
+        entries = bundle.entry.map(&:resource).sort_by(&:id)
 
         assert_equal('Harry', entries[0].name[0].given[0])
         assert_equal('Sotired', entries[0].name[0].family)


### PR DESCRIPTION
Adds the FHIR Patient/$everything operation for an individual patient. Not supported for patient list-at a time, but that could be implemented if desired. Also fixes a bug where the Patients in a Bundle weren't being wrapped in "Entry"s.