### PR TITLE
Epic integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ reports
 # Mac OS
 .DS_Store
 **/.DS_Store
+
+epic_client_secret.txt

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ reports
 .DS_Store
 **/.DS_Store
 
-epic_client_secret.txt
+# ignore local files that are good to have in the local project structure but not in the repo
+local_resources

--- a/app/controllers/oauth/callback_controller.rb
+++ b/app/controllers/oauth/callback_controller.rb
@@ -37,6 +37,7 @@ module Oauth
       pp.profile = req[:profile]
       pp.provider = req[:provider]
       pp.access_token = token.token
+      pp.expires_at = Time.now.to_i + token.expires_in
       pp.refresh_token = token.refresh_token
       pp.subject_id = pp.provider.subject_id_from_token(token)
       pp.scopes = token.params['scope']

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,6 @@ require 'fhir_models'
 require 'fhir_dstu2_models'
 require_relative '../lib/hdm'
 
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,8 +14,11 @@ require 'action_view/railtie'
 require 'action_cable/engine'
 # require "sprockets/railtie"
 require 'rails/test_unit/railtie'
-require_relative '../lib/hdm'
 require 'fhir_models'
+require 'fhir_dstu2_models'
+require_relative '../lib/hdm'
+
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/db/migrate/20180711203039_add_token_expiration_to_profile_providers.rb
+++ b/db/migrate/20180711203039_add_token_expiration_to_profile_providers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTokenExpirationToProfileProviders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :profile_providers, :expires_at, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_151200) do
+ActiveRecord::Schema.define(version: 2018_07_11_203039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -249,6 +249,7 @@ ActiveRecord::Schema.define(version: 2018_06_28_151200) do
     t.string "refresh_token"
     t.datetime "last_sync"
     t.string "scopes"
+    t.integer "expires_at"
     t.index ["profile_id"], name: "index_profile_providers_on_profile_id"
     t.index ["provider_id"], name: "index_profile_providers_on_provider_id"
   end

--- a/lib/hdm.rb
+++ b/lib/hdm.rb
@@ -3,5 +3,6 @@
 require 'fhir_models'
 require_relative 'hdm/client/client'
 require_relative 'hdm/client/smart_client'
+require_relative 'hdm/client/epic_smart_client'
 require_relative 'hdm/merge/merger'
 require_relative 'hdm/merge/generic_matcher'

--- a/lib/hdm/client/client.rb
+++ b/lib/hdm/client/client.rb
@@ -39,6 +39,7 @@ module HDM
           if access_token.expired?
             access_token = access_token.refresh!
             profile_provider.access_token = access_token.token
+            profile_provider.expires_at = Time.now.to_i + access_token.expires_in if access_token.expires_in
             profile_provider.refresh_token = access_token.refresh_token
             profile_provider.save
           end

--- a/lib/hdm/client/client.rb
+++ b/lib/hdm/client/client.rb
@@ -34,7 +34,7 @@ module HDM
           client = OAuth2::Client.new(provider.client_id, provider.client_secret, client_options)
           access_token = OAuth2::AccessToken.new(client, profile_provider.access_token,
                                                  refresh_token: profile_provider.refresh_token,
-                                                 expires_at: profile_provider.expires_at || Time.now.to_i)
+                                                 expires_at: profile_provider.expires_at || 1)
 
           if access_token.expired?
             access_token = access_token.refresh!

--- a/lib/hdm/client/client.rb
+++ b/lib/hdm/client/client.rb
@@ -5,8 +5,8 @@ module HDM
     def self.get_client(provider)
       if provider.provider_type == 'smart'
         HDM::Client::SmartClient.new(provider)
-      elsif provider.provider_type == "smart_epic"
-          HDM::Client::EpicSmartClient.new(provider)
+      elsif provider.provider_type == 'smart_epic'
+        HDM::Client::EpicSmartClient.new(provider)
       else
         BaseClient.new(provider)
       end
@@ -77,7 +77,7 @@ module HDM
         if provider.token_endpoint && provider.authorization_endpoint
           { authorize_url: provider.authorization_endpoint,
             token_url: provider.token_endpoint }
-        end 
+        end
       end
 
       def default_redirect_endpoint

--- a/lib/hdm/client/client.rb
+++ b/lib/hdm/client/client.rb
@@ -32,9 +32,11 @@ module HDM
         if profile_provider.refresh_token
           client_options = get_endpoint_params
           client = OAuth2::Client.new(provider.client_id, provider.client_secret, client_options)
-          access_token = OAuth2::AccessToken.new(client, profile_provider.access_token, refresh_token: profile_provider.refresh_token)
+          access_token = OAuth2::AccessToken.new(client, profile_provider.access_token,
+                                                 refresh_token: profile_provider.refresh_token,
+                                                 expires_at: profile_provider.expires_at || Time.now.to_i)
 
-          if access_token.refresh_token
+          if access_token.expired?
             access_token = access_token.refresh!
             profile_provider.access_token = access_token.token
             profile_provider.refresh_token = access_token.refresh_token

--- a/lib/hdm/client/client.rb
+++ b/lib/hdm/client/client.rb
@@ -5,6 +5,8 @@ module HDM
     def self.get_client(provider)
       if provider.provider_type == 'smart'
         HDM::Client::SmartClient.new(provider)
+      elsif provider.provider_type == "smart_epic"
+          HDM::Client::EpicSmartClient.new(provider)
       else
         BaseClient.new(provider)
       end
@@ -75,10 +77,7 @@ module HDM
         if provider.token_endpoint && provider.authorization_endpoint
           { authorize_url: provider.authorization_endpoint,
             token_url: provider.token_endpoint }
-        else
-          { authorize_url: provider.base_endpoint + '/auth/authorization',
-            token_url: provider.base_endpoint + '/auth/token' }
-        end
+        end 
       end
 
       def default_redirect_endpoint

--- a/lib/hdm/client/epic_smart_client.rb
+++ b/lib/hdm/client/epic_smart_client.rb
@@ -11,6 +11,10 @@ module HDM
         client = OAuth2::Client.new(provider.client_id, provider.client_secret, options)
         client.auth_code.get_token(code, params)
       end
+
+      def supported_resource_types
+        super - [FHIR::DSTU2::Observation]
+      end
     end
   end
 end

--- a/lib/hdm/client/epic_smart_client.rb
+++ b/lib/hdm/client/epic_smart_client.rb
@@ -1,0 +1,15 @@
+
+module HDM
+  module Client
+    class EpicSmartClient < SmartClient
+      def get_access_token(code, params = {})
+        options = get_endpoint_params
+        options[:site] = provider.base_endpoint
+        options[:raise_errors] = true
+        params[:redirect_uri] = default_redirect_endpoint
+        client = OAuth2::Client.new(provider.client_id, provider.client_secret, options)
+        client.auth_code.get_token(code, params)
+      end
+    end
+  end
+end

--- a/lib/hdm/client/epic_smart_client.rb
+++ b/lib/hdm/client/epic_smart_client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module HDM
   module Client

--- a/lib/hdm/client/smart_client.rb
+++ b/lib/hdm/client/smart_client.rb
@@ -47,7 +47,7 @@ module HDM
           bundle = reply.resource
 
           # don't bother storing empty results
-          next if bundle.nil? || bundle.entry.nil? || bundle.entry.none?
+          next if bundle.nil? || bundle.entry.nil? || bundle.entry.none? || bundle.total == 0
 
           receipt = DataReceipt.new(profile_id: profile_provider.profile.id,
                                     provider_id: provider.id,

--- a/lib/hdm/client/smart_client.rb
+++ b/lib/hdm/client/smart_client.rb
@@ -5,19 +5,19 @@ module HDM
     class SmartClient < BaseClient
       attr_accessor :fhir_client
       DEFAULT_STU3_TYPES = [FHIR::Patient,
-                       FHIR::Immunization,
-                       FHIR::Condition,
-                       FHIR::Device,
-                       FHIR::MedicationStatement,
-                       FHIR::Encounter,
-                       FHIR::Observation].freeze
-       DEFAULT_DSTU2_TYPES = [FHIR::DSTU2::Patient,
-                        FHIR::DSTU2::Immunization,
-                        FHIR::DSTU2::Condition,
-                        FHIR::DSTU2::Device,
-                        FHIR::DSTU2::MedicationStatement,
-                        FHIR::DSTU2::Encounter,
-                        FHIR::DSTU2::Observation].freeze
+                            FHIR::Immunization,
+                            FHIR::Condition,
+                            FHIR::Device,
+                            FHIR::MedicationStatement,
+                            FHIR::Encounter,
+                            FHIR::Observation].freeze
+      DEFAULT_DSTU2_TYPES = [FHIR::DSTU2::Patient,
+                             FHIR::DSTU2::Immunization,
+                             FHIR::DSTU2::Condition,
+                             FHIR::DSTU2::Device,
+                             FHIR::DSTU2::MedicationStatement,
+                             FHIR::DSTU2::Encounter,
+                             FHIR::DSTU2::Observation].freeze
       def intialize(provider)
         super(provider)
       end
@@ -71,14 +71,13 @@ module HDM
         version = fhir_client.detect_version
         version ||= :dstu2
         defaults = version == :dstu2 ? DEFAULT_DSTU2_TYPES : DEFAULT_STU3_TYPES
-        prefix = version == :dstu2 ? "FHIR::DSTU2" : "FHIR"
+        prefix = version == :dstu2 ? 'FHIR::DSTU2' : 'FHIR'
         types = []
         client_capability_statement.rest[0].resource.each do |r|
           types << "#{prefix}::#{r.type}".constantize if r.type != 'Patient' && r.searchParam.find { |sp| sp.name == 'patient' }
         end
         types.empty? ? defaults : types
       end
-
 
       def fhir_search_params(profile_provider)
         params = {}

--- a/test/controllers/oauth/callback_controller_test.rb
+++ b/test/controllers/oauth/callback_controller_test.rb
@@ -25,5 +25,7 @@ class Api::V1::ProfilesControllerTest < ActionDispatch::IntegrationTest
     provider = providers.first
     assert_equal data[:access_token], provider.access_token
     assert_equal data[:refresh_token], provider.refresh_token
+    assert provider.expires_at > Time.now.to_i
+    assert provider.expires_at <= Time.now.to_i + data[:expires_in]
   end
 end

--- a/test/fixtures/profile_providers.yml
+++ b/test/fixtures/profile_providers.yml
@@ -9,6 +9,8 @@ harry_partners:
   provider: partners
   subject_id: harrys_partners_paitent_id
   access_token: this_is_harrys_access_token
+  refresh_token: this_is_the_refresh_token
+  expires_at: 0 
 # column: value
 #
 sema_partners:


### PR DESCRIPTION
Changes required for integration with Epic systems (Based on initail App Orchard sandbox testing). 
In addition to the epic changes this PR also contains updated token refresh handling to deal with access token timeouts and only request a new access_token once it is expired.  Access tokens that do not have an expires_id field but do have a refresh token filed will be considered expired for every call and will request a new access token. 