### PR TITLE
Provider integration

### DIFF
--- a/app/controllers/api/v1/profile_providers_controller.rb
+++ b/app/controllers/api/v1/profile_providers_controller.rb
@@ -10,10 +10,14 @@ module Api
       def create
         profile = find_profile
         provider = find_provider
-        render json: { message: 'Provider already linked' }, status: :internal_server_error if profile.has_provider? provider
+        if profile.has_provider? provider
+          render json: { message: 'Provider already linked' }, status: :internal_server_error
+          return
+        end
         state = { provider_id: provider.id, profile_id: profile.id }.to_json
         state_enc = Base64.encode64(state)
-        render json: { redirect_uri: provider.generate_auth_url(state: state_enc) }, status: :ok
+        redirect_uri = provider.generate_auth_url(redirect_uri: params[:redirect_uri], state: state_enc)
+        render json: { redirect_uri: redirect_uri }, status: :ok
         # kick off the linking -- actual creation of the user_provider object happens
         # through an ouath2 flow to have the user log into the provider system and
         # grant access, the redirection of this will result in the object being created

--- a/app/controllers/oauth/callback_controller.rb
+++ b/app/controllers/oauth/callback_controller.rb
@@ -11,8 +11,8 @@ module Oauth
       # validate code
       req = discover_request
       token = req[:provider].get_access_token(params[:code])
-      link_provider_and_profile(token, req)
-      redirect_to "/profile/#{req[:profile].id}/providers/#{req[:provider].id}"
+      pp = link_provider_and_profile(token, req)
+      render json: { id: pp.id }, status: :ok
     end
 
     private
@@ -42,6 +42,7 @@ module Oauth
       pp.subject_id = pp.provider.subject_id_from_token(token)
       pp.scopes = token.params['scope']
       pp.save!
+      pp
     end
   end
 end

--- a/test/controllers/oauth/callback_controller_test.rb
+++ b/test/controllers/oauth/callback_controller_test.rb
@@ -19,7 +19,7 @@ class Api::V1::ProfilesControllerTest < ActionDispatch::IntegrationTest
 
     get '/oauth/callback', params: { code: code, state: state }
 
-    assert_redirected_to "http://www.example.com/profile/#{profile.id}/providers/#{provider.id}"
+    assert_response :ok
     providers = ProfileProvider.where(profile_id: profile.id, provider_id: provider.id)
     assert_equal 1, providers.count
     provider = providers.first


### PR DESCRIPTION
Slight rework to OAuth callback to support an additional layer of a UI in front of it. The UI will now provide the backend server the redirect_uri to provide to the oauth resource provider.
Additionally the callback controller will no longer redirect to a location that doesn't exist, it will just return the id of the newly created object.

This depends on changes in the hdm_ui `provider_integration` branch as well - PR to follow there.