### PR TITLE
Encounter Data Receipt concepts

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -19,8 +19,9 @@ module Api
                              data_type: 'fhir_bundle_edr')
         dr.save!
 
-        # run the sync job async
-        # SyncProfileJob.perform_later(profile)
+        # run the sync job asynchronously, so the request returns
+        # set fetch = false, so that it doesn't fetch, it only processes the things we added
+        SyncProfileJob.perform_later(profile, false)
 
         render status: :ok
       end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -19,7 +19,7 @@ module Api
                              data_type: 'fhir_bundle_edr')
         dr.save!
 
-        # run the sync job asynchronously, so the request returns
+        # run the sync job asynchronously, so the request returns quickly
         # set fetch = false, so that it doesn't fetch, it only processes the things we added
         SyncProfileJob.perform_later(profile, false)
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class BaseController < ApiController
+      def create
+        # identify provider based on the token
+        provider = ProviderApplication.find_by(application_id: doorkeeper_token.application_id).provider
+
+        bundle_json = request.body.read
+
+        # identify profile based on identifiers in the Patient entry
+        profile_id = find_profile_id(bundle_json)
+        profile = Profile.find(profile_id)
+
+        dr = DataReceipt.new(profile: profile,
+                             provider: provider,
+                             data: bundle_json,
+                             data_type: 'fhir_bundle_edr')
+        dr.save!
+
+        # run the sync job async
+        # SyncProfileJob.perform_later(profile)
+
+        render status: :ok
+      end
+
+      private
+
+      def find_profile_id(bundle_json)
+        bundle = FHIR::Json.from_json(bundle_json)
+        patient = bundle.entry.find { |e| e.resource.resourceType == 'Patient' }.resource
+        ids = patient.identifier
+        ident = ids.find { |id| id.system == 'urn:health_data_manager:profile_id' }
+        ident.value
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -23,7 +23,7 @@ module Api
         # set fetch = false, so that it doesn't fetch, it only processes the things we added
         SyncProfileJob.perform_later(profile, false)
 
-        render status: :ok
+        render status: :created
       end
 
       private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,11 @@ class ApplicationController < ActionController::API
 
   # Function to update the audit log as new events occur in a user's account.
   def update_log
-    recorded_user = current_resource_owner&.id || 'N/A'
+    recorded_user = begin
+                      current_resource_owner&.id || 'N/A'
+                    rescue ActiveRecord::RecordNotFound
+                      'N/A'
+                    end
     description = controller_name + ' ' + action_name
     params.each do |variable|
       description = description + ' ' + variable.to_s

--- a/app/jobs/sync_profile_job.rb
+++ b/app/jobs/sync_profile_job.rb
@@ -3,9 +3,11 @@
 class SyncProfileJob < ApplicationJob
   queue_as :default
 
-  def perform(profile)
+  # fetch: if true, will fetch the latest for the profile from the provider. 
+  # if false, will only run against what's already loaded
+  def perform(profile, fetch = true)
     profile.profile_providers.each do |pp|
-      SyncProfileProviderJob.perform_now(pp)
+      SyncProfileProviderJob.perform_now(pp, fetch)
     end
   end
 end

--- a/app/jobs/sync_profile_job.rb
+++ b/app/jobs/sync_profile_job.rb
@@ -3,11 +3,17 @@
 class SyncProfileJob < ApplicationJob
   queue_as :default
 
-  # fetch: if true, will fetch the latest for the profile from the provider. 
+  # fetch: if true, will fetch the latest for the profile from the provider.
   # if false, will only run against what's already loaded
   def perform(profile, fetch = true)
     profile.profile_providers.each do |pp|
       SyncProfileProviderJob.perform_now(pp, fetch)
     end
+
+    # fallback to catch any DRs that are associated with profiles/providers
+    # for which there is no profile_provider link created
+    # (for instance, an EDR where the person didn't already establish the link)
+    DataReceipt.where(profile: profile, processed: nil).each(&:process!)
+    HDM::Merge::Merger.new.update_profile(profile)
   end
 end

--- a/app/jobs/sync_profile_provider_job.rb
+++ b/app/jobs/sync_profile_provider_job.rb
@@ -3,9 +3,13 @@
 class SyncProfileProviderJob < ApplicationJob
   queue_as :default
 
-  def perform(profile_provider)
-    client = HDM::Client.get_client(profile_provider.provider)
-    client.sync_profile(profile_provider)
+  # fetch: if true, will fetch the latest for the profile from the provider. 
+  # if false, will only run against what's already loaded
+  def perform(profile_provider, fetch = true)
+    if fetch
+      client = HDM::Client.get_client(profile_provider.provider)
+      client.sync_profile(profile_provider)
+    end
     DataReceipt.where(profile: profile_provider.profile).each(&:process!)
     HDM::Merge::Merger.new.update_profile(profile_provider.profile)
   end

--- a/app/jobs/sync_profile_provider_job.rb
+++ b/app/jobs/sync_profile_provider_job.rb
@@ -3,14 +3,14 @@
 class SyncProfileProviderJob < ApplicationJob
   queue_as :default
 
-  # fetch: if true, will fetch the latest for the profile from the provider. 
+  # fetch: if true, will fetch the latest for the profile from the provider.
   # if false, will only run against what's already loaded
   def perform(profile_provider, fetch = true)
     if fetch
       client = HDM::Client.get_client(profile_provider.provider)
       client.sync_profile(profile_provider)
     end
-    DataReceipt.where(profile: profile_provider.profile).each(&:process!)
+    DataReceipt.where(profile: profile_provider.profile, processed: nil).each(&:process!)
     HDM::Merge::Merger.new.update_profile(profile_provider.profile)
   end
 end

--- a/app/models/provider_application.rb
+++ b/app/models/provider_application.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ProviderApplication < ApplicationRecord
+  belongs_to :provider
+  belongs_to :application, class_name: 'Doorkeeper::Application'
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -67,7 +67,7 @@ Doorkeeper.configure do
   # falls back to the `:client_id` and `:client_secret` params from the `params` object.
   # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
   # for more information on customization
-  # client_credentials :from_basic, :from_params
+  client_credentials :from_basic, :from_params
 
   # Change the way access token is authenticated from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
@@ -120,7 +120,7 @@ Doorkeeper.configure do
   #   http://tools.ietf.org/html/rfc6819#section-4.4.3
   #
   # grant_flows %w[password authorization_code client_credentials]
-  grant_flows %w[password]
+  grant_flows %w[password client_credentials]
   # Hook into the strategies' request & response life-cycle in case your
   # application needs advanced customization or logging:
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
   get '/oauth/callback', action: :callback, controller: 'oauth/callback'
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
+      # Base FHIR endpoint to allow POSTing of transactions
+      # per https://www.hl7.org/fhir/http.html#transaction
+      post '/', to: 'base#create'
+
       curated_models = %i[allergy_intolerances care_plans conditions
                           devices documents encounters goals immunizations
                           medication_administrations medication_requests medication_statements

--- a/db/migrate/20180803134246_create_provider_application.rb
+++ b/db/migrate/20180803134246_create_provider_application.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateProviderApplication < ActiveRecord::Migration[5.2]
+  def change
+    create_table :provider_applications do |t|
+      t.references :provider, null: false
+      t.references :application, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_20_122541) do
+ActiveRecord::Schema.define(version: 2018_08_03_134246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -283,6 +283,15 @@ ActiveRecord::Schema.define(version: 2018_07_20_122541) do
     t.string "telephone"
     t.string "telephone_use"
     t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
+
+  create_table "provider_applications", force: :cascade do |t|
+    t.bigint "provider_id", null: false
+    t.bigint "application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id"], name: "index_provider_applications_on_application_id"
+    t.index ["provider_id"], name: "index_provider_applications_on_provider_id"
   end
 
   create_table "providers", force: :cascade do |t|

--- a/lib/tasks/hdm.rake
+++ b/lib/tasks/hdm.rake
@@ -85,4 +85,37 @@ namespace :hdm do
     DataReceipt.where(profile: pp.profile).each(&:process!)
     HDM::Merge:: Merger.new.update_profile(pp.profile)
   end
+
+  desc 'Create Doorkeeper Application for Provider'
+  task :create_provider_application, [] => :environment do |_t, _args|
+    providers = Provider.all.to_a
+    provider_indx = 0
+
+    if providers.empty?
+      puts 'There are no providers in the system, please load some providers before continuing'
+      return
+    elsif providers.length > 1
+      puts 'Select which provider you want to associate the token with '
+      providers.each_with_index { |p, i| puts "#{i} #{p.name}" }
+      provider_indx = STDIN.gets.chomp.to_i
+    else
+      puts "There is only 1 provider in the system, using provider #{providers[provider_indx.to_i].name}"
+    end
+    provider = providers[provider_indx.to_i]
+
+    pa = ProviderApplication.find_by(provider: provider)
+
+    if pa
+      app = pa.application
+      puts 'Found existing application for provider: '
+    else
+      app = Doorkeeper::Application.create(name: provider.name, redirect_uri: 'http://example.com')
+      ProviderApplication.create(provider_id: provider.id, application_id: app.id)
+      puts 'Created successfully.'
+    end
+
+    puts app.inspect
+    puts "Client ID: #{app.uid}"
+    puts "Client Secret: #{app.secret}"
+  end
 end

--- a/lib/tasks/provider_client.rake
+++ b/lib/tasks/provider_client.rake
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :provider_client do
+  desc 'Simulate Posting Encounter Data Receipt'
+  task :post_edr, %i[file] => :environment do |_t, args|
+    bundle_json = File.open(args.file, 'r:UTF-8').read
+
+    users = User.all.to_a
+    providers = Provider.all.to_a
+    user_indx = 0
+    profile_indx = 0
+    provider_indx = 0
+
+    if users.empty?
+      puts 'There are no users in the system, please add a user before continuing'
+      return
+    elsif users.length > 1
+      puts 'Select which user you want to load the data for '
+      users.each_with_index { |u, i| puts "#{i}. #{u.email}" }
+      user_indx = STDIN.gets.chomp.to_i
+    else
+      puts "Using only user in the system: #{users[user_indx].email}"
+    end
+
+    user = users[user_indx]
+    profiles = user.profiles
+    if profiles.empty?
+      puts 'User has no profile, please create a profile before continuing'
+      return
+    elsif profiles.length > 1
+      puts 'Select which profile you want to load the data into '
+      profiles.each_with_index { |p, i| puts "#{i}. #{p.name}" }
+      profile_indx = STDIN.gets.chomp.to_i
+    else
+      puts "User only has a single profile, using profile #{profiles[profile_indx.to_i].name}"
+    end
+
+    if providers.empty?
+      puts 'There are no providers in the system, please load some providers before continuing'
+    elsif providers.length > 1
+      puts 'Select which provider you want to associate the EDR with '
+      providers.each_with_index { |p, i| puts "#{i} #{p.name}" }
+      provider_indx = STDIN.gets.chomp.to_i
+    else
+      puts "There is only 1 provider in the system, using provider #{providers[provider_indx.to_i].name}"
+    end
+    profile = profiles[profile_indx.to_i]
+    provider = providers[provider_indx.to_i]
+
+    # inject the profile ID into the bundle.
+    # nearly the same logic as extracting the id in BaseController
+    bundle = FHIR::Json.from_json(bundle_json)
+    patient = bundle.entry.find { |e| e.resource.resourceType == 'Patient' }.resource
+    ids = patient.identifier
+    ident = ids.find { |id| id.system == 'urn:health_data_manager:profile_id' }
+    if ident
+      puts 'Found HDM profile_id identifier. Overwriting value to selected profile.id'
+      ident.value = profile.id
+    else
+      puts 'Injecting profile_id into patient identifier list'
+      ids << FHIR::Identifier.new(system: 'urn:health_data_manager:profile_id', value: profile.id)
+    end
+    bundle_json = bundle.to_json
+
+    # get the provider client_id and client_secret to get the token
+    pa = ProviderApplication.find_by(provider: provider)
+
+    unless pa
+      puts 'No application found for provider.'
+      puts 'Run the hdm:create_provider_application rake task to create an application for this provider.'
+      return
+    end
+
+    app = pa.application
+    client_id = app.uid
+    client_secret = app.secret
+
+    uri = URI('https://localhost:3000/oauth/token')
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.body = "grant_type=client_credentials&client_id=#{client_id}&client_secret=#{client_secret}"
+
+    response = http.request(request)
+
+    token = JSON.parse(response.body)['access_token']
+
+    uri = URI('https://localhost:3000/api/v1/')
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request['Authorization'] = "Bearer #{token}"
+    request.body = bundle_json
+
+    response = http.request(request)
+
+    # TODO: maybe more error handling?
+    puts response.message
+  end
+end

--- a/lib/tasks/provider_client.rake
+++ b/lib/tasks/provider_client.rake
@@ -90,6 +90,7 @@ namespace :provider_client do
     http = Net::HTTP.new(uri.host, uri.port)
     request = Net::HTTP::Post.new(uri.request_uri)
     request['Authorization'] = "Bearer #{token}"
+    request['Content-Type'] = 'application/json'
     request.body = bundle_json
 
     response = http.request(request)

--- a/test/controllers/api/v1/base_controller_test.rb
+++ b/test/controllers/api/v1/base_controller_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module V1
+    class BaseControllerTest < ActionDispatch::IntegrationTest
+      test 'should be able to post EDR bundle' do
+        user = users(:harry)
+        profile = user.profiles.first
+
+        provider = providers(:bwh)
+        app = generate_application(provider)
+        token = generate_app_token(app.id)
+
+        bundle_json = load_bundle('Harris789_Stark857_2159d1ae-e556-4533-978d-be1f9812607d')
+        # hardcoding the ID caused some issues with other tests so we have to manually set it in the bundle
+        bundle_json.gsub!('BASE_CONTROLLER_TEST_PLACEHOLDER_ID', profile.id.to_s)
+
+        post '/api/v1/', params: bundle_json, headers: { authorization: "Bearer #{token.token}" }
+        assert_response :created
+
+        assert DataReceipt.find_by(profile_id: profile.id, provider_id: provider.id)
+      end
+
+      def load_bundle(name)
+        File.read("./test/fixtures/files/bundles/#{name}.json")
+      end
+
+      def generate_application(provider)
+        app = Doorkeeper::Application.create(name: provider.name, redirect_uri: 'https://example.com')
+        ProviderApplication.create(provider_id: provider.id, application_id: app.id)
+        app
+      end
+
+      def generate_app_token(application_id)
+        token = Doorkeeper::AccessToken.new(application_id: application_id)
+        token.save!
+        token
+      end
+    end
+  end
+end

--- a/test/fixtures/files/bundles/Harris789_Stark857_2159d1ae-e556-4533-978d-be1f9812607d.json
+++ b/test/fixtures/files/bundles/Harris789_Stark857_2159d1ae-e556-4533-978d-be1f9812607d.json
@@ -123,6 +123,10 @@
             "value": "2159d1ae-e556-4533-978d-be1f9812607d"
           },
           {
+            "system": "urn:health_data_manager:profile_id",
+            "value": "BASE_CONTROLLER_TEST_PLACEHOLDER_ID"
+          },
+          {
             "type": {
               "coding": [
                 {


### PR DESCRIPTION
Adds the following:

1) A ProviderApplication class, to link together Providers and Doorkeeper's Applications (aka clients).  Applications have client IDs and client secrets which can be used to get an access token.

2) A new rake task in the HDM namespace, to create a ProviderApplication for a given provider.

3) A BaseController, for the base FHIR url at [endpoint]/api/v1/ which will accept a POSTed bundle. (as per https://www.hl7.org/fhir/http.html#transaction) This is only expected to be used by providers submitting Electronic Data Receipts, so the Provider is obtained by lookup via the doorkeeper token, and the Profile id is pulled from an identifier in the Patient resource. When a Bundle is POSTed here, it gets added to the db as a DataReceipt, and then the SyncProfileJob is called async to process it. Note that a new parameter is added to the SyncProfileJob so that it will only process the existing DR, not fetch new ones.

4) A new rake task to simulate a provider submitting an EDR. The task will take in a bundle, allow the user to choose a profile and provider, then inject the given profile ID into the bundle and POST it to the controller as the given provider. The intent is that this task will add convenience by looking up IDs in the DB, but it could easily be extracted out to a separate project.