### PR TITLE
Profile provider timestamps

### DIFF
--- a/db/migrate/20180828184951_add_timestamps_to_profile_providers.rb
+++ b/db/migrate/20180828184951_add_timestamps_to_profile_providers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTimestampsToProfileProviders < ActiveRecord::Migration[5.2]
   def change
     add_column :profile_providers, :created_at, :timestamp

--- a/db/migrate/20180828184951_add_timestamps_to_profile_providers.rb
+++ b/db/migrate/20180828184951_add_timestamps_to_profile_providers.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToProfileProviders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :profile_providers, :created_at, :timestamp
+    add_column :profile_providers, :updated_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_14_173524) do
+ActiveRecord::Schema.define(version: 2018_08_28_184951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -290,6 +290,8 @@ ActiveRecord::Schema.define(version: 2018_08_14_173524) do
     t.datetime "last_sync"
     t.string "scopes"
     t.integer "expires_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["profile_id"], name: "index_profile_providers_on_profile_id"
     t.index ["provider_id"], name: "index_profile_providers_on_provider_id"
   end


### PR DESCRIPTION
just adding the update and create timestamps to the profile_providers model, left off by typo in original migration