### PR TITLE
OperationOutcomes contain the 2 conflicting resources

### DIFF
--- a/app/controllers/api/v1/curated_models_controller.rb
+++ b/app/controllers/api/v1/curated_models_controller.rb
@@ -41,6 +41,12 @@ module Api
                    end
       end
 
+      def wrap_in_bundle(results)
+        # get just the FHIR resources, but then wrap it in an Entry.
+        resources = results.map { |r| { resource: r.fhir_model.to_hash } }
+        FHIR::Bundle.new(type: 'searchset', entry: resources)
+      end
+
       def filtered_params
         params.permit(:profile_id, :id)
       end

--- a/app/controllers/api/v1/operation_outcomes_controller.rb
+++ b/app/controllers/api/v1/operation_outcomes_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class OperationOutcomesController < CuratedModelsController
+    end
+  end
+end

--- a/app/controllers/api/v1/patients_controller.rb
+++ b/app/controllers/api/v1/patients_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class PatientsController < ApiController
       def index
-        patients = current_resource_owner.profiles.map { |p| wrap_in_entry(p.to_patient) }
+        patients = current_resource_owner.profiles.map { |p| { resource: p.to_patient.to_hash } }
 
         bundle = FHIR::Bundle.new(type: 'searchset', entry: patients)
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -2,22 +2,4 @@
 
 class ApiController < ApplicationController
   # before_action -> { doorkeeper_authorize! :api }
-
-  def wrap_in_bundle(results)
-    # get just the FHIR resources, but then wrap it in an Entry.
-    resources = results.map { |r| wrap_in_entry(r.resource) }
-    FHIR::Bundle.new(type: 'searchset', entry: resources)
-  end
-
-  def wrap_in_entry(obj)
-    # FHIR::X.new() requires that these be hashes, not strings or full FHIR objects
-
-    if obj.is_a? String
-      obj = JSON.parse(obj)
-    elsif obj.is_a? FHIR::Model
-      obj = obj.to_hash
-    end
-
-    { resource: obj }
-  end
 end

--- a/app/models/concerns/curated_model.rb
+++ b/app/models/concerns/curated_model.rb
@@ -3,6 +3,7 @@
 require 'uuid'
 module CuratedModel
   extend ActiveSupport::Concern
+  include FHIRWrapper
 
   included do
     validates :resource, presence: true
@@ -19,10 +20,6 @@ module CuratedModel
     end
   end
 
-  def fhir_model
-    @fhir_model ||= from_json
-  end
-
   # empty method, should be implemented in classes
   def update_resource
     if fhir_model.respond_to? :patient
@@ -33,16 +30,6 @@ module CuratedModel
   end
 
   private
-
-  def from_json
-    if resource.instance_of? String
-      FHIR.from_contents(resource)
-    else
-      resource_type = resource['resourceType']
-      klass = Module.const_get("FHIR::#{resource_type}")
-      klass.new(resource)
-    end
-  end
 
   def generate_resource_id
     self.resource_id = UUID.generate

--- a/app/models/concerns/fhir_wrapper.rb
+++ b/app/models/concerns/fhir_wrapper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module FHIRWrapper
+  extend ActiveSupport::Concern
+
+  def fhir_model
+    @fhir_model ||= from_json
+  end
+
+  private
+
+  def from_json
+    if resource.instance_of? String
+      FHIR.from_contents(resource)
+    else
+      resource_type = resource['resourceType']
+      klass = Module.const_get("FHIR::#{resource_type}")
+      klass.new(resource)
+    end
+  end
+end

--- a/app/models/operation_outcome.rb
+++ b/app/models/operation_outcome.rb
@@ -39,7 +39,9 @@ class OperationOutcome < ApplicationRecord
     # path defines a place in the object tree, fields or indices separated by .
     value = hash
 
-    path.split('.').each do |key|
+    # the regex means split on . or array indices
+    # ex: "component[0].valueQuantity.value" ==> ["component", "0", "valueQuantity", "value"]
+    path.split(/(?:\[(\d+)\])?\./).each do |key|
       key = key.to_i if value.is_a? Array
       value = value[key]
       return nil if value.nil?

--- a/app/models/operation_outcome.rb
+++ b/app/models/operation_outcome.rb
@@ -3,8 +3,12 @@
 class OperationOutcome < ApplicationRecord
   include CuratedModel
   belongs_to :profile
-  after_find do |oo| # rubocop:disable Style/SymbolProc # rubocop's suggestion here breaks it
+  after_find do |oo|
     oo.find_diagnostics
+
+    # add the referenced conflicting resources to the fhir_models "contained"
+    # note that these are not persisted if the OperationOutcome is saved
+    oo.fhir_model.contained.push(target.fhir_model, conflict.fhir_model)
   end
 
   def target

--- a/app/models/operation_outcome.rb
+++ b/app/models/operation_outcome.rb
@@ -3,4 +3,57 @@
 class OperationOutcome < ApplicationRecord
   include CuratedModel
   belongs_to :profile
+  after_find do |oo| # rubocop:disable Style/SymbolProc # rubocop's suggestion here breaks it
+    oo.find_diagnostics
+  end
+
+  def target
+    @target ||= @target_class.find_by(resource_id: @target_id)
+  end
+
+  def conflict
+    @conflict ||= @conflict_class.find_by(id: @conflict_id)
+  end
+
+  def compare
+    comparison = {}
+    location = fhir_model.issue[0].location
+
+    left = target.resource
+    right = conflict.resource
+
+    if location.is_a? String
+      comparison[location] = { left: get_value(left, location), right: get_value(right, location) }
+    else
+      location.each { |l| comparison[l] = { left: get_value(left, l), right: get_value(right, l) } }
+    end
+
+    comparison
+  end
+
+  def get_value(hash, path)
+    # path defines a place in the object tree, fields or indices separated by .
+    value = hash
+
+    path.split('.').each do |key|
+      key = key.to_i if value.is_a? Array
+      value = value[key]
+      return nil if value.nil?
+    end
+
+    value
+  end
+
+  def find_diagnostics
+    description = fhir_model.issue[0].diagnostics
+    # format is target_type:id;conflict_type:id
+    fields = description.split(/[;:]/)
+
+    # only cache these in vars for now, don't make the DB call until actually needed
+    @target_class = fields[0].constantize
+    @target_id = fields[1]
+
+    @conflict_class = fields[2].constantize
+    @conflict_id = fields[3]
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -63,7 +63,7 @@ class Profile < ApplicationRecord
 
   def bundle_everything
     bundle = wrap_in_bundle(all_resources)
-    bundle.entry.insert(0, wrap_in_entry(to_patient))
+    bundle.entry.insert(0, resource: to_patient.to_hash)
     bundle
   end
 
@@ -73,22 +73,10 @@ class Profile < ApplicationRecord
 
   private
 
-  # TODO: find a common location for both these 2 functions and the ones in ApiController
+  # TODO: find a common location for this functions and the one in CuratedModelsController
   def wrap_in_bundle(results)
     # get just the FHIR resources, but then wrap it in an Entry.
-    resources = results.map { |r| wrap_in_entry(r.resource) }
+    resources = results.map { |r| { resource: r.fhir_model.to_hash } }
     FHIR::Bundle.new(type: 'searchset', entry: resources)
-  end
-
-  def wrap_in_entry(obj)
-    # FHIR::X.new() requires that these be hashes, not strings or full FHIR objects
-
-    if obj.is_a? String
-      obj = JSON.parse(obj)
-    elsif obj.is_a? FHIR::Model
-      obj = obj.to_hash
-    end
-
-    { resource: obj }
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -22,14 +22,13 @@ class Profile < ApplicationRecord
   has_many :explanation_of_benefits
   has_many :coverages
   has_many :claims
+  has_many :operation_outcomes # internal OperationOutcomes from deconflicting resources
   # IMPORTANT - if adding new resource types above,
   #             also add them to the all_resources method below
 
   # resources are the raw resources that are created from transactions, they
   # do not equate to the currated data models resources
   has_many :resources
-  # internal OperationOutcomes from deconflicting resources
-  has_many :operation_outcomes
 
   def has_provider?(provider_id)
     return false if provider_id.nil?
@@ -42,7 +41,7 @@ class Profile < ApplicationRecord
                documents encounters goals immunizations
                medication_administrations medication_requests
                medication_statements observations procedures
-               explanation_of_benefits coverages claims]
+               explanation_of_benefits coverages claims operation_outcomes]
 
     rs = []
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Resource < ApplicationRecord
+  include FHIRWrapper
+
   belongs_to :data_receipt
   belongs_to :profile
   belongs_to :provider

--- a/lib/hdm/merge/generic_matcher.rb
+++ b/lib/hdm/merge/generic_matcher.rb
@@ -4,7 +4,7 @@ module HDM
   module Merge
     class GenericMatcher
       MATCH_THRESHOLD = 0.8
-      NON_COMPARABLE_PATHS = %w[url system id _id text reference resourcetype].freeze
+      NON_COMPARABLE_PATHS = %w[url system id _id text reference resourcetype meta].freeze
       FLOAT_TOLERANCE = 0.0001
       DATETIME_REGEX = Regexp.new(FHIR::PRIMITIVES['dateTime']['regex']).freeze
 

--- a/lib/hdm/merge/generic_matcher.rb
+++ b/lib/hdm/merge/generic_matcher.rb
@@ -53,16 +53,15 @@ module HDM
       end
 
       def self.traverse(obj, path_map = {}, path = '')
-        prefix = path == '' ? '' : path + '.'
-
         case obj
         when Hash
+          prefix = path == '' ? '' : path + '.'
           obj.each { |k, v| traverse(v, path_map, prefix + k.to_s) }
         when Array
           # TODO: IMPORTANT -- this compares array contents by index
           # meaning 2 arrays with equivalent contents but different order
           # will not match. we should review
-          obj.each_with_index { |v, i| traverse(v, path_map, prefix + i.to_s) }
+          obj.each_with_index { |v, i| traverse(v, path_map, "#{path}[#{i}]") }
         else
           path_map[path] = obj
         end


### PR DESCRIPTION
The internal "merge and deconflict" algorithm creates OperationOutcomes when 2 items are found to be conflicting. Sample:

```
{
   "id":"7615a820-981c-0136-e887-244cc8386f27",
   "issue":[
      {
         "code":"conflict",
         "location":[
            "component[0].valueQuantity.value",
            "component[1].valueQuantity.value"
         ],
         "severity":"information",
         "diagnostics":"Observation:6a4e2d90-981c-0136-e887-244cc8386f27;Resource:1720"
      }
   ],
   "resourceType":"OperationOutcome"
}
```

The `diagnostics` field indicates the 2 objects that are conflicting, as `type_1:id_1;type_2:id_2`. The `location` field indicates which fields within those objects have conflicting values. The format for the fields is hopefully self-explanatory, and also intended to be valid [FHIRPath](http://hl7.org/fhirpath/)

As of today it is possible to fetch the curated model (in this sample Observation) via the FHIR API, but there is no way to fetch the conflicting Resource. 

To make things easier for the UI, I'm proposing adding the curated model and the conflicting Resource directly to the OperationOutcome using the `contained` field. Sample below. These will then be included along with the Patient/$everything bundle for the UI to display alerts as appropriate.

Any concerns or issues with this approach? @rdingwell @noranda 

Note this PR also includes some slightly relevant cleanup

```
{
  "id": "7615a820-981c-0136-e887-244cc8386f27",
  "contained": [
    {
      "id": "6a4e2d90-981c-0136-e887-244cc8386f27",
      "meta": {
        "profile": [
          "http://standardhealthrecord.org/fhir/StructureDefinition/shr-finding-Observation",
          "http://standardhealthrecord.org/fhir/StructureDefinition/shr-vital-VitalSign",
          "http://standardhealthrecord.org/fhir/StructureDefinition/shr-vital-BloodPressure"
        ]
      },
      "status": "final",
      "category": [
        {
          "coding": [
            {
              "system": "http://hl7.org/fhir/observation-category",
              "code": "vital-signs",
              "display": "vital-signs"
            }
          ]
        }
      ],
      "code": {
        "coding": [
          {
            "system": "http://loinc.org",
            "code": "55284-4",
            "display": "Blood Pressure"
          }
        ],
        "text": "Blood Pressure"
      },
      "subject": {
        "reference": "Patient/9bb73f5f-22fe-4b48-b7b1-fec836b47b9e"
      },
      "context": {
        "reference": "urn:uuid:0087fb77-cab9-42a1-b77b-f6de90dadb7b"
      },
      "effectiveDateTime": "2015-03-04T13:20:24-05:00",
      "issued": "2015-03-04T13:20:24.114-05:00",
      "component": [
        {
          "code": {
            "coding": [
              {
                "system": "http://loinc.org",
                "code": "8462-4",
                "display": "Diastolic Blood Pressure"
              }
            ],
            "text": "Diastolic Blood Pressure"
          },
          "valueQuantity": {
            "value": 74.75795137331639,
            "unit": "mmHg",
            "system": "http://unitsofmeasure.org",
            "code": "mmHg"
          }
        },
        {
          "code": {
            "coding": [
              {
                "system": "http://loinc.org",
                "code": "8480-6",
                "display": "Systolic Blood Pressure"
              }
            ],
            "text": "Systolic Blood Pressure"
          },
          "valueQuantity": {
            "value": 100.2166269939004,
            "unit": "mmHg",
            "system": "http://unitsofmeasure.org",
            "code": "mmHg"
          }
        }
      ],
      "resourceType": "Observation"
    },
    {
      "id": "57471668-b152-426f-928f-393d0c792f41",
      "meta": {
        "profile": [
          "http://standardhealthrecord.org/fhir/StructureDefinition/shr-finding-Observation",
          "http://standardhealthrecord.org/fhir/StructureDefinition/shr-vital-VitalSign",
          "http://standardhealthrecord.org/fhir/StructureDefinition/shr-vital-BloodPressure"
        ]
      },
      "status": "final",
      "category": [
        {
          "coding": [
            {
              "system": "http://hl7.org/fhir/observation-category",
              "code": "vital-signs",
              "display": "vital-signs"
            }
          ]
        }
      ],
      "code": {
        "coding": [
          {
            "system": "http://loinc.org",
            "code": "55284-4",
            "display": "Blood Pressure"
          }
        ],
        "text": "Blood Pressure"
      },
      "subject": {
        "reference": "urn:uuid:c5f8ac26-2565-48c5-81cf-997809372cd6"
      },
      "context": {
        "reference": "urn:uuid:47fd4d93-9289-43f7-8335-c4e1091c098f"
      },
      "effectiveDateTime": "2015-03-04T15:51:30-05:00",
      "issued": "2015-03-04T15:51:30.056-05:00",
      "component": [
        {
          "code": {
            "coding": [
              {
                "system": "http://loinc.org",
                "code": "8462-4",
                "display": "Diastolic Blood Pressure"
              }
            ],
            "text": "Diastolic Blood Pressure"
          },
          "valueQuantity": {
            "value": 75.45932795892273,
            "unit": "mmHg",
            "system": "http://unitsofmeasure.org",
            "code": "mmHg"
          }
        },
        {
          "code": {
            "coding": [
              {
                "system": "http://loinc.org",
                "code": "8480-6",
                "display": "Systolic Blood Pressure"
              }
            ],
            "text": "Systolic Blood Pressure"
          },
          "valueQuantity": {
            "value": 104.87108410321952,
            "unit": "mmHg",
            "system": "http://unitsofmeasure.org",
            "code": "mmHg"
          }
        }
      ],
      "resourceType": "Observation"
    }
  ],
  "issue": [
    {
      "severity": "information",
      "code": "conflict",
      "diagnostics": "Observation:6a4e2d90-981c-0136-e887-244cc8386f27;Resource:1720",
      "location": [
        "component[0].valueQuantity.value",
        "component[1].valueQuantity.value"
      ]
    }
  ],
  "resourceType": "OperationOutcome"
}
```