### PR TITLE
Make dates "required" fields in deconfliction logic

### DIFF
--- a/lib/hdm/merge/generic_matcher.rb
+++ b/lib/hdm/merge/generic_matcher.rb
@@ -171,7 +171,7 @@ module HDM
 
       # return true if any single element of the given path exists in the given list
       def self.part_in_list?(path, list)
-        list.any? { |ncp| path.downcase.split('.').include?(ncp) }
+        list.any? { |ncp| path.downcase.split(/(?:\[(\d+)\])?\./).include?(ncp) }
       end
 
       def self.create_issue(source_resource_type, source_resource_id, target_resource_type, target_resource_id, conflict_paths)

--- a/test/fixtures/resources.yml
+++ b/test/fixtures/resources.yml
@@ -43,10 +43,10 @@ imperfect_match_resource:
   resource: '{"resourceType": "Condition",
               "id": "17",
               "code": {"coding": [{"system": "http://hl7.org/fhir/sid/icd-10", "code": "Q84.1" }]},
-              "clinicalStatus": "active",
+              "clinicalStatus": "inactive",
               "verificationStatus": "confirmed",
               "onsetDateTime": "2001-01-16T21:03:10-05:00",
-              "assertedDate": "2001-01-23T21:03:10-05:00",
+              "assertedDate": "2001-01-16T21:03:10-05:00",
               "subject": {"reference": "some-internal-id-here"}}'
 
 unmatching_resource:

--- a/test/fixtures/resources.yml
+++ b/test/fixtures/resources.yml
@@ -32,6 +32,23 @@ perfect_match_resource:
               "assertedDate": "2001-01-16T21:03:10-05:00",
               "subject": {"reference": "some-internal-id-here"}}'
 
+diff_date_perfect_match_resource:
+  id: 8
+  profile: jills_profile
+  provider: partners
+  data_receipt: first_data_receipt
+  resource_type: Condition
+  provider_resource_id: 12345
+  provider_resource_version: 1
+  resource: '{"resourceType": "Condition",
+              "id": "7",
+              "code": {"coding": [{"system": "http://hl7.org/fhir/sid/icd-10", "code": "Q84.1" }]},
+              "clinicalStatus": "active",
+              "verificationStatus": "confirmed",
+              "onsetDateTime": "2018-01-16T21:03:10-05:00",
+              "assertedDate": "2018-01-16T21:03:10-05:00",
+              "subject": {"reference": "some-internal-id-here"}}'
+
 imperfect_match_resource:
   id: 17
   profile: jills_profile

--- a/test/unit/lib/hdm/merge/generic_matcher_test.rb
+++ b/test/unit/lib/hdm/merge/generic_matcher_test.rb
@@ -63,7 +63,7 @@ module HDM
         assert_equal(1, outcome.issue.length)
         issue = outcome.issue[0]
         assert_equal(1, issue.location.length) # only 1 field mismatched
-        assert_equal('assertedDate', issue.location[0])
+        assert_equal('clinicalStatus', issue.location[0])
 
         assert_includes(issue.diagnostics, "Condition:#{expected.id}") # id of the matching curated model resource
         assert_includes(issue.diagnostics, "Resource:#{resource.id}") # id of the Resource itself

--- a/test/unit/lib/hdm/merge/generic_matcher_test.rb
+++ b/test/unit/lib/hdm/merge/generic_matcher_test.rb
@@ -47,6 +47,17 @@ module HDM
         assert_nil outcome
       end
 
+      test 'should not match on otherwise perfect match with different date' do
+        profile = profiles(:jills_profile)
+        relationship = profile.conditions
+
+        resource = resources(:diff_date_perfect_match_resource)
+        json = JSON.parse(resource.resource)
+        match = GenericMatcher.match(json, relationship)
+
+        assert_nil match
+      end
+
       test 'should create operation outcome for deconfliction on imperfect match' do
         profile = profiles(:jills_profile)
         relationship = profile.conditions


### PR DESCRIPTION
Updates the deconfliction logic so that certain date fields are "required" and if these fields do not match then the resource as a whole necessarily will not match. 

This is implemented by naming specific date fields as required rather than making all fields with a date in them automatically required, for 3 reasons. 1 - this is easier to extend to other fields, for example the primary code on a Condition, where code is just a string so we couldn't make all strings required, 2 - I didn't want to automatically restrict any date fields that weren't necessarily part of the "primary key" of the resource. It's far from perfect but I think it's a step in the right direction for our use cases, and 3 - our ability to correctly identify FHIR date types is not perfect at the moment.